### PR TITLE
Bug fix - duplicate entries in LocalStorage

### DIFF
--- a/src/main/java/es/eucm/gleaner/tracker/Tracker.java
+++ b/src/main/java/es/eucm/gleaner/tracker/Tracker.java
@@ -193,6 +193,7 @@ public class Tracker {
 			this.tracker = tracker;
 		}
 
+		@Override
 		public void handleHttpResponse(HttpResponse httpResponse) {
 			if (httpResponse.getStatus().getStatusCode() == 200) {
 				String data = httpResponse.getResultAsString();
@@ -212,10 +213,12 @@ public class Tracker {
 			tracker.traceFormat.startData(data);
 		}
 
+		@Override
 		public void failed(Throwable t) {
 			tracker.setConnecting(false);
 		}
 
+		@Override
 		public void cancelled() {
 			tracker.setConnecting(false);
 		}
@@ -223,17 +226,20 @@ public class Tracker {
 
 	public class FlushListener implements HttpResponseListener {
 
+		@Override
 		public void handleHttpResponse(HttpResponse httpResponse) {
-			if (httpResponse.getStatus().getStatusCode() == 200) {
+			if (httpResponse.getStatus().getStatusCode()/100 == 2) {
 				sent.clear();
 			}
 			setSending(false);
 		}
 
+		@Override
 		public void failed(Throwable t) {
 			setSending(false);
 		}
 
+		@Override
 		public void cancelled() {
 			setSending(false);
 		}

--- a/src/test/java/es/eucm/gleaner/tracker/storage/LocalStorageTest.java
+++ b/src/test/java/es/eucm/gleaner/tracker/storage/LocalStorageTest.java
@@ -56,6 +56,8 @@ public class LocalStorageTest {
 	public void testTraces() {
 		tracker.start();
 		tracker.zone("zone1");
+		tracker.requestFlush();
+		tracker.update(0);
 		tracker.screen("screen1");
 		tracker.requestFlush();
 		tracker.update(0);


### PR DESCRIPTION
`FlushListener` only accepts 200 as valid response, while `LocalStorage` sends a 204 code. As a consequence, `sent` never gets emptied. 

The test did not identify the bug because it can only be perceived when new traces are queued and flush is requested a second+ time (otherwise `queue` is empty and no entries are sent again to storage).
